### PR TITLE
Refactor Jobs repository to use Firestore

### DIFF
--- a/assets/lang/en.json
+++ b/assets/lang/en.json
@@ -377,6 +377,15 @@
     },
     "chat_room": {
         "placeholder": "Enter a message..."
+    },
+    "jobs": {
+        "form": {
+            "titleHint": "Job title",
+            "descriptionHint": "Describe the position",
+            "categoryHint": "Category",
+            "locationHint": "Location",
+            "submit": "Post Job"
+        }
     }
-    
+
 }

--- a/assets/lang/id.json
+++ b/assets/lang/id.json
@@ -376,7 +376,15 @@
     },
     "chat_room": {
         "placeholder": "Ketik pesan..."
+    },
+    "jobs": {
+        "form": {
+            "titleHint": "Judul pekerjaan",
+            "descriptionHint": "Deskripsikan posisi",
+            "categoryHint": "Kategori",
+            "locationHint": "Lokasi",
+            "submit": "Pasang Lowongan"
+        }
     }
-
 
 }

--- a/assets/lang/ko.json
+++ b/assets/lang/ko.json
@@ -364,6 +364,15 @@
     },
     "chat_room": {
         "placeholder": "메시지를 입력하세요..."
+    },
+    "jobs": {
+        "form": {
+            "titleHint": "공고 제목",
+            "descriptionHint": "업무 내용을 입력",
+            "categoryHint": "직종 카테고리",
+            "locationHint": "근무 위치",
+            "submit": "구인 등록"
+        }
     }
 
 }


### PR DESCRIPTION
## Summary
- refactor `JobRepository` to use Firestore instead of in-memory list
- add translation keys for job posting forms in English, Indonesian and Korean

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870fbc2f734832a9eaeff0aa58edac7